### PR TITLE
Set hostname the old fashioned way

### DIFF
--- a/parts/base.sh
+++ b/parts/base.sh
@@ -35,5 +35,6 @@ EOF
 
 # Set hostname
 original_hostname=$(uname -n)
-hostnamectl set-hostname robot
+echo robot > /etc/hostname
+hostname robot
 sed -i 's/$original_hostname/robot/gi' /etc/hosts


### PR DESCRIPTION
hostnamectl fails when run in the chroot.