### PR TITLE
Install runusb from pre-built deb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/runusb"]
-	path = packages/runusb
-	url = https://github.com/sourcebots/runusb.git

--- a/parts/base.sh
+++ b/parts/base.sh
@@ -10,8 +10,7 @@ apt-get -y install \
     htop \
     git \
     python3-pip \
-    build-essential \
-    devscripts
+    build-essential
 
 # Add line to config.txt
 echo 'VIDEO_CAMERA = "1"' >> /boot/config.txt

--- a/parts/cleanup.sh
+++ b/parts/cleanup.sh
@@ -3,8 +3,6 @@ set -eux -o pipefail
 
 systemctl disable hciuart
 
-apt-get remove --yes devscripts
-
 apt-get autoremove --yes
 
 apt-get clean --yes

--- a/parts/robot.sh
+++ b/parts/robot.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 set -eux -o pipefail
 
-export PACKAGES_DIR=/tmp/packer-packages
-
 echo "Storage=persistent" >> /etc/systemd/journald.conf
 
-cd $PACKAGES_DIR/runusb
-debuild -uc -us
-
-apt-get install -y $PACKAGES_DIR/*.deb
+# Download and install runusb
+wget -O /tmp/runusb.deb https://github.com/sourcebots/runusb/releases/download/2023.0.0rc1/runusb_2023.0.0rc1_all.deb
+apt-get install -y /tmp/runusb.deb
 
 # Install and configure udiskie
 apt-get install -y udiskie

--- a/pi.json
+++ b/pi.json
@@ -43,11 +43,6 @@
         "destination": "/tmp/packer-files"
       },
       {
-        "type": "file",
-        "source": "./packages/",
-        "destination": "/tmp/packer-packages"
-      },
-      {
         "type": "shell",
         "environment_vars": [
           "SB_NAME={{user `SB_NAME`}}",


### PR DESCRIPTION
This significantly improves build time, and removes the need to install debian's dev scripts

Currently untested.