### PR TITLE
Ensure job has correct permissions for releases publish

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write 
     name: Build image
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This prevented the previous release from running correctly.

It's unfortunate we use this token for _all_ builds, but it should be fine for our usage.