### PR TITLE
Add option to build without compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ crash.log
 output-*/
 
 # End of https://www.toptal.com/developers/gitignore/api/packer
-output.img*
+*-image-*.img*

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Packer scripts to build SourceBots robot image
 
 ## Usage
 
-Simply run the `./build-image.sh` script. Packer will download all needed files and save the output image to `output.img`, ready for further compression and/or distribution.
+Simply run the `./build-image.sh` script. Packer will download all needed files and save the output image to `Source OS-image-<GIT-TAG/HASH>.img.xz`, ready for distribution. Running `./build-image.sh fast` will skip the compression step, which greatly speeds up the build process.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Packer scripts to build SourceBots robot image
 
 ## Usage
 
-Simply run the `./build-image.sh` script. Packer will download all needed files and save the output image to `Source OS-image-<GIT-TAG/HASH>.img.xz`, ready for distribution. Running `./build-image.sh fast` will skip the compression step, which greatly speeds up the build process.
+Simply run the `./build-image.sh` script. Packer will download all needed files and save the output image to `Source OS-image-<GIT-TAG/HASH>.img.xz`, ready for distribution. Running `./build-image.sh nocompress` will skip the compression step, which greatly speeds up the build process.

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+if [ $1 == "fast" ]; then
+    SKIP_COMPRESSION="true"
+else
+    SKIP_COMPRESSION="false"
+fi
 
 SB_NAME="Source OS"
 SB_VERSION="$(git describe --tags --always)"
 
 rm -f *-image-*.img.xz
+rm -f *-image-*.img
 
 docker run --rm --privileged \
     -v /dev:/dev \
@@ -12,4 +18,5 @@ docker run --rm --privileged \
     build \
     -var "SB_NAME=${SB_NAME}" \
     -var "SB_VERSION=${SB_VERSION}" \
+    -var "SKIP_COMPRESSION=${SKIP_COMPRESSION}" \
     pi.json

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ $1 == "fast" ]; then
+if [ $1 == "nocompress" ]; then
     SKIP_COMPRESSION="true"
 else
     SKIP_COMPRESSION="false"

--- a/pi.json
+++ b/pi.json
@@ -1,7 +1,8 @@
 {
     "variables": {
       "SB_NAME": "",
-      "SB_VERSION": ""
+      "SB_VERSION": "",
+      "SKIP_COMPRESSION": "false"
     },
     "builders": [{
       "type": "arm",
@@ -60,7 +61,11 @@
     "post-processors": [
       {
         "type": "shell-local",
-        "inline": ["xz -vT0 \"{{user `SB_NAME`}}-image-{{user `SB_VERSION`}}.img\""]
+        "inline": [
+          "if [ \"{{user `SKIP_COMPRESSION`}}\" != \"true\" ]; then",
+          "xz -vT0 \"{{user `SB_NAME`}}-image-{{user `SB_VERSION`}}.img\"",
+          "fi"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Running `./build-image.sh fast` instead of `./build-image.sh` now skips compressing the output image.