### PR TITLE
Remove faulty rpi.gpio-common package

### DIFF
--- a/parts/robot.sh
+++ b/parts/robot.sh
@@ -33,6 +33,11 @@ systemctl enable runusb.service
 
 group=plugdev
 
+# Remove a buggy udev package that breaks the USB tree if FTDI chips are plugged into too many USB hubs
+# See https://github.com/raspberrypi/linux/issues/3779#issuecomment-709481662 
+# and https://groups.google.com/g/linux.debian.bugs.dist/c/5jI9dDZgfUU
+apt-get remove -y rpi.gpio-common
+
 # Create a group and add the default user to it.
 groupadd --force $group
 usermod -a -G $group robot


### PR DESCRIPTION
There's bug with the rpi.gpio-common udev rule that causes the root hub to be made only readable by root when the motor board is plugged in too far down the USB tree.

Seen in SR2024 with motor boards connected to 7 port USB hubs

> PSA: Connect your motor board to specific ports to avoid "No boards of this type found" errors
> 
> Hello all,
> 
> We've been investigating an issue where a "No boards of this type found" error is thrown for the power board. We've tracked the issue down to a bug in the Raspberry Pi OS where plugging the motor board into certain ports causes all boards to be undetectable. 
> 
> To mitigate this issue, please plug your motor board either directly into the Raspberry Pi or into the 3 ports closest to the input of the hub, as shown in the image below.
> 
> ![image](https://github.com/sourcebots/robot-image/assets/10937272/45a48746-a287-4993-8a57-8ef3a47307c4)
>
> For anyone using their own devices, if your device uses an FTDI chip, please plug it into the same ports as listed above.

See https://github.com/srobo/robot-image/issues/79,  https://github.com/raspberrypi/linux/issues/3779#issuecomment-709481662 and https://groups.google.com/g/linux.debian.bugs.dist/c/5jI9dDZgfUU