### PR TITLE
Add support for KCH boot progress leds

### DIFF
--- a/parts/files/leds/boot_40.service
+++ b/parts/files/leds/boot_40.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Boot Progress 40%
+[Service]
+Type=simple
+ExecStart=/usr/bin/set-led 5 1
+
+[Install]
+WantedBy=basic.target

--- a/parts/files/leds/boot_60.service
+++ b/parts/files/leds/boot_60.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Boot Progress 60%
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/set-led 12 1
+
+[Install]
+WantedBy=multi-user.target

--- a/parts/files/leds/boot_80.service
+++ b/parts/files/leds/boot_80.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Boot Progress 80%
+BindsTo=runusb.service
+After=runusb.service
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/set-led 6 1
+ExecStop=/usr/bin/set-led 6 0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/parts/files/leds/set-led
+++ b/parts/files/leds/set-led
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+led_num="$1"
+led_level="$2"
+
+echo "$led_num" > /sys/class/gpio/export
+echo out > /sys/class/gpio/gpio${led_num}/direction
+echo "$led_level" > /sys/class/gpio/gpio5/value
+echo "$led_num" > /sys/class/gpio/unexport

--- a/parts/robot.sh
+++ b/parts/robot.sh
@@ -34,7 +34,7 @@ systemctl enable runusb.service
 group=plugdev
 
 # Remove a buggy udev package that breaks the USB tree if FTDI chips are plugged into too many USB hubs
-# See https://github.com/raspberrypi/linux/issues/3779#issuecomment-709481662 
+# See https://github.com/raspberrypi/linux/issues/3779#issuecomment-709481662
 # and https://groups.google.com/g/linux.debian.bugs.dist/c/5jI9dDZgfUU
 apt-get remove -y rpi.gpio-common
 
@@ -53,3 +53,11 @@ SUBSYSTEM=="tty", DRIVERS=="ftdi_sio", ATTRS{interface}=="MCV4B", GROUP="$group"
 # SR servo board v4
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1bda", ATTRS{idProduct}=="0011", GROUP="$group", MODE="0666"
 EOF
+
+# Setup KCH leds triggered by systemd
+cp /tmp/packer-files/leds/set-led /usr/bin/
+chmod +x /usr/bin/set-led
+cp /tmp/packer-files/leds/*.service /lib/systemd/system/
+systemctl enable boot_40.service
+systemctl enable boot_60.service
+systemctl enable boot_80.service


### PR DESCRIPTION
Boot 20%: EEPROM loaded
Boot 40%: systemd started
Boot 60%: network started
Boot 80%: runusb service started